### PR TITLE
Fix random runtime crash processing discontiguous data

### DIFF
--- a/Sources/Data+Gzip.swift
+++ b/Sources/Data+Gzip.swift
@@ -177,8 +177,9 @@ extension Data {
         guard !self.isEmpty else {
             return Data()
         }
-        
-        var stream = self.createZStream()
+
+        let contiguousData = self.withUnsafeBytes {Data(bytes: $0, count: self.count)}
+        var stream = contiguousData.createZStream()
         var status: Int32
         
         status = deflateInit2_(&stream, level.rawValue, Z_DEFLATED, MAX_WBITS + 16, MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY, ZLIB_VERSION, Int32(DataSize.stream))
@@ -225,8 +226,9 @@ extension Data {
         guard !self.isEmpty else {
             return Data()
         }
-        
-        var stream = self.createZStream()
+
+        let contiguousData = self.withUnsafeBytes {Data(bytes: $0, count: self.count)}
+        var stream = contiguousData.createZStream()
         var status: Int32
         
         status = inflateInit2_(&stream, MAX_WBITS + 32, ZLIB_VERSION, Int32(DataSize.stream))
@@ -240,11 +242,11 @@ extension Data {
             throw GzipError(code: status, msg: stream.msg)
         }
         
-        var data = Data(capacity: self.count * 2)
+        var data = Data(capacity: contiguousData.count * 2)
         
         repeat {
             if Int(stream.total_out) >= data.count {
-                data.count += self.count / 2
+                data.count += contiguousData.count / 2
             }
             
             data.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Bytef>) in


### PR DESCRIPTION
minimum changes to fix #22 

This PR copies self into contiguous data before deflating and inflating, regardless of whether self is contiguous or discontiguous.
The defensive patch consumes more temporary memory. It's better than random runtime crash.

I could not add tests for that as I saw the crashs randomly on devices and not on the simulator.

Alternative fixes:

Although I think about other fixes, they need some more work.

* changing `createZStream` to `withZStream<T>(block: (z_stream) -> T) -> T` may reduce memory copy for already contiguous data (by Swift lib or Foundation)
* using `enumerateBytes` in deflating and inflating could directly read both contiguous and discontiguous data
