### PR TITLE
fix OC pod error

### DIFF
--- a/GzipSwift.podspec
+++ b/GzipSwift.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name          = "GzipSwift"
   s.version       = "5.0.0"
+  s.swift_version = '5.0'
   s.summary       = "Swift framework that enables gzip/gunzip Data using zlib."
 
   s.homepage      = "https://github.com/1024jp/GzipSwift"


### PR DESCRIPTION
`GzipSwift` does not specify a Swift version and none of the targets 