### PR TITLE
Add support for managing the size of the history buffer

### DIFF
--- a/Sources/Gzip/Data+Gzip.swift
+++ b/Sources/Gzip/Data+Gzip.swift
@@ -156,11 +156,10 @@ extension Data {
     ///
     /// The `wBits` parameter allows for managing the size of the history buffer. The possible values are:
     ///
-    ///     Value                        Window size logarithm    Input
-    ///     +8 to +15                    Base 2                   Includes zlib header and trailer
-    ///     -8 to -15                    Absolute value of wbits  Raw stream with no header and trailer
-    ///     +24 to +31 = 16 + (8 to 15)  Low 4 bits of the value  Includes gzip header and trailer
-    ///     +40 to +47 = 32 + (8 to 15)  Low 4 bits of the value  zlib or gzip format
+    ///     Value       Window size logarithm    Input
+    ///     +9 to +15   Base 2                   Includes zlib header and trailer
+    ///     -9 to -15   Absolute value of wbits  No header and trailer
+    ///     +25 to +31  Low 4 bits of the value  Includes gzip header and trailing checksum
     ///
     /// - Parameter level: Compression level.
     /// - Parameter wBits: Manage the size of the history buffer.

--- a/Sources/Gzip/Data+Gzip.swift
+++ b/Sources/Gzip/Data+Gzip.swift
@@ -211,9 +211,18 @@ extension Data {
     /// Create a new `Data` instance by decompressing the receiver using zlib.
     /// Throws an error if decompression failed.
     ///
+    /// The `wBits` parameter allows for managing the size of the history buffer. The possible values are:
+    ///
+    ///     Value                        Window size logarithm    Input
+    ///     +8 to +15                    Base 2                   Includes zlib header and trailer
+    ///     -8 to -15                    Absolute value of wbits  Raw stream with no header and trailer
+    ///     +24 to +31 = 16 + (8 to 15)  Low 4 bits of the value  Includes gzip header and trailer
+    ///     +40 to +47 = 32 + (8 to 15)  Low 4 bits of the value  zlib or gzip format
+    ///
+    /// - Parameter wBits: Manage the size of the history buffer.
     /// - Returns: Gzip-decompressed `Data` instance.
     /// - Throws: `GzipError`
-    public func gunzipped() throws -> Data {
+    public func gunzipped(wBits: Int32 = MAX_WBITS + 32) throws -> Data {
         
         guard !self.isEmpty else {
             return Data()
@@ -222,7 +231,7 @@ extension Data {
         var stream = z_stream()
         var status: Int32
         
-        status = inflateInit2_(&stream, MAX_WBITS + 32, ZLIB_VERSION, Int32(DataSize.stream))
+        status = inflateInit2_(&stream, wBits, ZLIB_VERSION, Int32(DataSize.stream))
         
         guard status == Z_OK else {
             // inflateInit2 returns:

--- a/Sources/Gzip/Data+Gzip.swift
+++ b/Sources/Gzip/Data+Gzip.swift
@@ -34,11 +34,8 @@ import struct Foundation.Data
     import zlib
 #endif
 
-#if os(Linux)
-    public let MAX_WBITS = zliblinux.MAX_WBITS
-#else
-    public let MAX_WBITS = zlib.MAX_WBITS
-#endif
+/// Maximum value for windowBits (`MAX_WBITS`)
+public let maxWindowBits = MAX_WBITS
 
 /// Compression level whose rawValue is based on the zlib's constants.
 public struct CompressionLevel: RawRepresentable {

--- a/Tests/GzipTests/GzipTests.swift
+++ b/Tests/GzipTests/GzipTests.swift
@@ -106,7 +106,7 @@ final class GzipTests: XCTestCase {
         dHIPIYjvjjbRUSTKjmZHs6N/6WhVStS01VnRrGhW9BeKXsML
         """
         let data = try XCTUnwrap(Data(base64Encoded: encoded))
-        let uncompressed = try data.gunzipped(wBits: -MAX_WBITS)
+        let uncompressed = try data.gunzipped(wBits: -maxWindowBits)
         let json = String(data: uncompressed, encoding: .utf8)
         XCTAssertEqual(json?.first, "{")
         XCTAssertEqual(json?.last, "}")

--- a/Tests/GzipTests/GzipTests.swift
+++ b/Tests/GzipTests/GzipTests.swift
@@ -30,11 +30,6 @@
 
 import XCTest
 import Gzip
-#if os(Linux)
-    import zlibLinux
-#else
-    import zlib
-#endif
 
 final class GzipTests: XCTestCase {
     

--- a/Tests/GzipTests/GzipTests.swift
+++ b/Tests/GzipTests/GzipTests.swift
@@ -30,6 +30,11 @@
 
 import XCTest
 import Gzip
+#if os(Linux)
+    import zlibLinux
+#else
+    import zlib
+#endif
 
 final class GzipTests: XCTestCase {
     
@@ -96,7 +101,21 @@ final class GzipTests: XCTestCase {
         XCTAssertTrue(data.isGzipped)
         XCTAssertEqual(String(data: uncompressed, encoding: .utf8), "test")
     }
-    
+
+    func testDecompressionWithNoHeaderAndTrailer() throws {
+        let encoded = """
+        7ZOxCsIwEIbf5ea0JNerqdmdFeygFYciHYK0lTZOIe9u9AXMTTpkOQ\
+        h8hLv/7vNwmFfr7DyBuXho7Tisrh8fYAAlYiF1oWSr0EgyhCWRrpsa\
+        OxCwm9xihxWMB/UuR9e7Z3zCfmqX/naPyAmMFHD+1C7WIKBKRykdrd\
+        PRTTqqJINlZKAYkylOv006i4zZEBksY8HIyKFi5EuMf0kzroxzZowc\
+        dHIPIYjvjjbRUSTKjmZHs6N/6WhVStS01VnRrGhW9BeKXsML
+        """
+        let data = try XCTUnwrap(Data(base64Encoded: encoded))
+        let uncompressed = try data.gunzipped(wBits: -MAX_WBITS)
+        let json = String(data: uncompressed, encoding: .utf8)
+        XCTAssertEqual(json?.first, "{")
+        XCTAssertEqual(json?.last, "}")
+    }
 }
 
 


### PR DESCRIPTION
Being able to adjust the size of the history buffer is necessary to compress/decompress data in different formats, for example, a stream containing no header/trailer (see table 1 and table 2 on [this article](https://stackabuse.com/python-zlib-library-tutorial/)).

The changes include a test for decompressing data adjusting the WBITS parameter to -15.