### PR TITLE
Support decompression for combined compression

### DIFF
--- a/Tests/GzipTests/GzipTests.swift
+++ b/Tests/GzipTests/GzipTests.swift
@@ -116,9 +116,9 @@ final class GzipTests: XCTestCase {
         XCTAssertEqual(json?.last, "}")
     }
 
-    func testMultipleDecompression() throws {
-        let firstData = try "test".data(using: .utf8)!.gzipped()
-        let secondData = try "string".data(using: .utf8)!.gzipped()
+    func testDecompressionCompositedCompression() throws {
+        let firstData = try XCTUnwrap("test".data(using: .utf8)).gzipped()
+        let secondData = try XCTUnwrap("string".data(using: .utf8)).gzipped()
 
         let data = firstData + secondData
 

--- a/Tests/GzipTests/GzipTests.swift
+++ b/Tests/GzipTests/GzipTests.swift
@@ -96,6 +96,19 @@ final class GzipTests: XCTestCase {
         XCTAssertTrue(data.isGzipped)
         XCTAssertEqual(String(data: uncompressed, encoding: .utf8), "test")
     }
+
+
+    func testMultipleDecompression() throws {
+        let firstData = try "test".data(using: .utf8)!.gzipped()
+        let secondData = try "string".data(using: .utf8)!.gzipped()
+
+        let data = firstData + secondData
+
+        let uncompressed = try data.gunzipped()
+
+        XCTAssertTrue(data.isGzipped)
+        XCTAssertEqual(String(data: uncompressed, encoding: .utf8), "teststring")
+    }
     
 }
 


### PR DESCRIPTION
Currently, after merging the array of compressed elements, if you decompress this composite, only the first compressed one comes out.
I updated all elements to be decompressed.

**AS-IS**
gunzip(gzip("a") + gzip("b")) // "a"

**TO-BE**
gunzip(gzip("a") + gzip("b")) // "ab"