### PR TITLE
Break immediately when `inflate` exactly reaches the end of the buffer.

### DIFF
--- a/Sources/Gzip/Data+Gzip.swift
+++ b/Sources/Gzip/Data+Gzip.swift
@@ -211,7 +211,7 @@ extension Data {
                 stream.next_in = nil
             }
             
-        } while stream.avail_out == 0
+        } while stream.avail_out == 0 && status != Z_STREAM_END
         
         guard deflateEnd(&stream) == Z_OK, status == Z_STREAM_END else {
             throw GzipError(code: status, msg: stream.msg)


### PR DESCRIPTION
This PR adds a extra `Z_STREAM_END` check for `inflate` status to break immediately when it exactly reaches the end of the output buffer.