### PR TITLE
Fix misspelled type `uInt`.

### DIFF
--- a/Sources/Gzip/Data+Gzip.swift
+++ b/Sources/Gzip/Data+Gzip.swift
@@ -201,7 +201,7 @@ extension Data {
             
             self.withUnsafeBytes { (inputPointer: UnsafeRawBufferPointer) in
                 stream.next_in = UnsafeMutablePointer<Bytef>(mutating: inputPointer.bindMemory(to: Bytef.self).baseAddress!).advanced(by: Int(stream.total_in))
-                stream.avail_in = uint(inputCount) - uInt(stream.total_in)
+                stream.avail_in = uInt(inputCount) - uInt(stream.total_in)
                 
                 data.withUnsafeMutableBytes { (outputPointer: UnsafeMutableRawBufferPointer) in
                     stream.next_out = outputPointer.bindMemory(to: Bytef.self).baseAddress!.advanced(by: Int(stream.total_out))
@@ -277,7 +277,7 @@ extension Data {
                 self.withUnsafeBytes { (inputPointer: UnsafeRawBufferPointer) in
                     let inputStartPosition = totalIn + stream.total_in
                     stream.next_in = UnsafeMutablePointer<Bytef>(mutating: inputPointer.bindMemory(to: Bytef.self).baseAddress!).advanced(by: Int(inputStartPosition))
-                    stream.avail_in = uint(inputCount) - uInt(inputStartPosition)
+                    stream.avail_in = uInt(inputCount) - uInt(inputStartPosition)
                     
                     data.withUnsafeMutableBytes { (outputPointer: UnsafeMutableRawBufferPointer) in
                         let outputStartPosition = totalOut + stream.total_out


### PR DESCRIPTION
This PR fixes the misspelled type `uInt`:

`uint` is defined at `sys/types.h`:
<img width="674" alt="Screenshot 2023-05-07 at 14 01 29" src="https://user-images.githubusercontent.com/8158163/236660799-18144f8f-d873-4793-a875-1cc863c595a8.png">

and `uInt` is defined at `zconf.h` instead:
<img width="674" alt="Screenshot 2023-05-07 at 14 02 45" src="https://user-images.githubusercontent.com/8158163/236660812-569940f2-d181-455c-af34-b5429f5fa30a.png">

Should make no difference since they are both `unsigned int`, but it would be great to keep the data types consitent.
