### PR TITLE
Renamed swift version variable in Package.swift to fix deprecation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,5 +21,5 @@ let package = Package(
             resources: [.copy("test.txt.gz")]
         ),
     ],
-    swiftLanguageVersions: [.v6]
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
When I checked out your library today, the swift compiler was telling me about a deprecation. When comparing the old and the new version, I noticed that it only seems to be that the name of the variable inside the `Package.swift` was renamed, but on the first glance everything else stays the same.  \
This is why in this pull request, I renamed said variable `swiftLanguageVersions` to `swiftLanguageModes`.