### PR TITLE
feat: support linuxbrew installed zlib headers

### DIFF
--- a/Sources/Gzip/Data+Gzip.swift
+++ b/Sources/Gzip/Data+Gzip.swift
@@ -29,7 +29,13 @@
 import struct Foundation.Data
 
 #if os(Linux)
-    import zlibLinux
+    #if canImport(zlibLinux)
+        import zlibLinux
+    #elseif canImport(zlibHomebrew)
+        import zlibHomebrew
+    #else
+        import zlib
+    #endif
 #else
     import zlib
 #endif

--- a/Sources/system-zlib/include/module.modulemap
+++ b/Sources/system-zlib/include/module.modulemap
@@ -4,3 +4,10 @@ module zlibLinux [system] {
     link "z"
     export *
 }
+
+module zlibHomebrew [system] {
+    header "/home/linuxbrew/.linuxbrew/include/zlib.h"
+    header "/home/linuxbrew/.linuxbrew/include/zconf.h"
+    link "z"
+    export *
+}


### PR DESCRIPTION
- 👋 while building https://github.com/Homebrew/homebrew-core/pull/201480 for linux, seeing some build failures searching linux headers

```
  /tmp/xclogparser-20241217-6857-xho898/XCLogParser-0.2.40/.build/checkouts/GzipSwift/Sources/system-zlib/include/module.modulemap:2:12: error: header '/usr/include/zlib.h' not found
  1 | module zlibLinux [system] {
  2 |     header "/usr/include/zlib.h"
    |            `- error: header '/usr/include/zlib.h' not found
  3 |     header "/usr/include/zconf.h"
  4 |     link "z"
  
  /tmp/xclogparser-20241217-6857-xho898/XCLogParser-0.2.40/.build/checkouts/GzipSwift/Sources/Gzip/Data+Gzip.swift:32:12: error: could not build C module 'zlibLinux'
   30 | 
   31 | #if os(Linux)
   32 |     import zlibLinux
      |            `- error: could not build C module 'zlibLinux'
   33 | #else
   34 |     import zlib
```

linuxbrew (which is homebrew for linux) actually installs the zlib headers in `${brew --prefix}`, thus adding a `zlibHomebrew` module lookup.

I am new to this, open for better thoughts. Thanks!