### PR TITLE
update macOS, Xcode in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on: [push, pull_request]
 jobs:
   macOS:
     name: Test on macOS
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.0.app
+      DEVELOPER_DIR: /Applications/Xcode_16.4.0.app
     steps:
     - uses: actions/checkout@v4
     - name: Show environments

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,12 +10,12 @@ on:
 
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
-  DEVELOPER_DIR: /Applications/Xcode_16.0.app
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app
   
 jobs:
   analyze:
     name: Analyze
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
[Xcode 16.0 is no longer available on macOS 14.](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md)