### PR TITLE
change to swiftLanguageModes from Versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,5 +21,5 @@ let package = Package(
             resources: [.copy("test.txt.gz")]
         ),
     ],
-    swiftLanguageVersions: [.v6]
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
```
'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is deprecated: replaced by 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)'
```

```
Use 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)' instead
```